### PR TITLE
✨ Feature : 월간 분석 상세 리포트, 월간 소비 내역 상세 API

### DIFF
--- a/src/main/java/com/nitrogen/domain/expense/controller/ExpenseReportController.java
+++ b/src/main/java/com/nitrogen/domain/expense/controller/ExpenseReportController.java
@@ -1,5 +1,6 @@
 package com.nitrogen.domain.expense.controller;
 
+import com.nitrogen.domain.expense.dto.report.detail.MonthlyDetailReportResponse;
 import com.nitrogen.domain.expense.dto.report.detail.WeeklyDetailReportResponse;
 import com.nitrogen.domain.expense.dto.report.summary.MonthlyReportArrivalResponse;
 import com.nitrogen.domain.expense.dto.report.summary.MonthlyReportSummaryResponse;
@@ -9,11 +10,14 @@ import com.nitrogen.domain.expense.dto.weeklyAndmonthly.TotalOpenStatusResponse;
 import com.nitrogen.domain.expense.repository.ExpenseRepository;
 import com.nitrogen.domain.expense.service.inquiry.ExpenseInquiryService;
 import com.nitrogen.domain.expense.service.report.DailyRetrospectReportService;
+import com.nitrogen.domain.expense.service.report.MonthlyDetailRecordService;
 import com.nitrogen.domain.expense.service.report.WeeklyRecordService;
 import com.nitrogen.domain.expense.service.report.TotalOpenStatusService;
 import com.nitrogen.domain.expense.service.report.WeeklyDetailRecordService;
 import com.nitrogen.domain.user.entity.CustomUserDetails;
 import com.nitrogen.global.apiPayload.ApiResponse;
+import com.nitrogen.global.apiPayload.code.status.ErrorStatus;
+import com.nitrogen.global.apiPayload.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +43,7 @@ public class ExpenseReportController {
 
     private final WeeklyRecordService weeklyRecordService;
     private final WeeklyDetailRecordService weeklyDetailRecordService;
+    private final MonthlyDetailRecordService monthlyDetailRecordService;
     private final DailyRetrospectReportService dailyRetrospectReportService;
     private final ExpenseRepository expenseRepository;
     private final ExpenseInquiryService expenseInquiryService;
@@ -127,6 +132,33 @@ public class ExpenseReportController {
         }
 
         return ApiResponse.onSuccess(responses);
+    }
+
+    @Operation(summary = "월간 분석 상세 리포트 조회", description = "해당 월의 월간 분석 상세 리포트를 조회합니다. 다음 달 1일 오전 8시 이후에 열람 가능합니다.")
+    @GetMapping("/monthly_detail")
+    public ApiResponse<MonthlyDetailReportResponse> getMonthlyDetailReport(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month) {
+
+        Long userId = userDetails.getUserId();
+        LocalDateTime nowDateTime = LocalDateTime.now();
+
+        LocalDate startOfMonth = LocalDate.of(year, month, 1);
+        LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
+
+        // 월간 리포트는 다음달 1일 오전 8시에 오픈
+        LocalDateTime monthlyOpenDateTime = startOfMonth.plusMonths(1).atTime(8, 0);
+        if (nowDateTime.isBefore(monthlyOpenDateTime)) {
+            throw new GeneralException(ErrorStatus.MONTHLY_REPORT_NOT_OPENED);
+        }
+
+        String monthTitle = String.format("%d년 %d월 분석 리포트", year, month);
+
+        MonthlyDetailReportResponse response = monthlyDetailRecordService.generateMonthlyDetailReport(
+                userId, startOfMonth, endOfMonth, monthTitle);
+
+        return ApiResponse.onSuccess(response);
     }
 
     @Operation(summary = "일별 종합 소비 만족도 조회", description = "당일 모든 지출에 대한 회고가 완료된 경우, 전체 만족도 평균을 문구로 반환합니다.")

--- a/src/main/java/com/nitrogen/domain/expense/controller/remind_grouping_expenselist/MonthlyExpenseDetailController.java
+++ b/src/main/java/com/nitrogen/domain/expense/controller/remind_grouping_expenselist/MonthlyExpenseDetailController.java
@@ -1,0 +1,39 @@
+package com.nitrogen.domain.expense.controller.remind_grouping_expenselist;
+
+import com.nitrogen.domain.expense.dto.report.detail.remind_grouping_expenselist.MonthlyExpenseDetailResponse;
+import com.nitrogen.domain.expense.entity.enums.EmotionType;
+import com.nitrogen.domain.expense.service.report.remind_grouping_expenselist.MonthlyExpenseDetailService;
+import com.nitrogen.domain.user.entity.CustomUserDetails;
+import com.nitrogen.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/monthly-reports")
+public class MonthlyExpenseDetailController {
+
+    private final MonthlyExpenseDetailService monthlyExpenseDetailService;
+
+    @Operation(summary = "월간 리포트 - 회고별 소비 내역 상세 조회", description = "선택한 마음 항목에 해당하는 지출만 필터링한 뒤, 그 안에서 회고별로 소비 상세 내역을 조회합니다.")
+    @GetMapping("/details")
+    public ApiResponse<MonthlyExpenseDetailResponse> getMonthlyExpenseDetails(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam EmotionType emotionType
+    ) {
+        Long userId = userDetails.getUserId();
+
+        MonthlyExpenseDetailResponse response = monthlyExpenseDetailService.getMonthlyExpenseDetailList(
+                userId, year, month, emotionType
+        );
+
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/nitrogen/domain/expense/dto/report/detail/MonthlyDetailReportResponse.java
+++ b/src/main/java/com/nitrogen/domain/expense/dto/report/detail/MonthlyDetailReportResponse.java
@@ -1,0 +1,24 @@
+package com.nitrogen.domain.expense.dto.report.detail;
+
+import com.nitrogen.domain.expense.dto.report.summary.EmotionDetailSummary;
+import com.nitrogen.domain.expense.dto.report.summary.EmotionSummary;
+import com.nitrogen.domain.expense.dto.report.summary.EvaluationSummary;
+
+import java.util.List;
+
+public record MonthlyDetailReportResponse(
+
+        String monthTitle, // 월간 범위 (예: 2026년 1월 분석 리포트)
+        String monthStartDate, // 월 시작일 (yyyy.MM.dd)
+        String monthEndDate, // 월 종료일 (yyyy.MM.dd)
+        String emotionFeedbackMessage, // 마음항목 관점 평균만족도 문장(상단)
+        EmotionSummary topEmotion, // 가장 많이 소비한 마음
+        String evaluationFeedbackMessage, // 소비회고 관점 평균만족도 문장(하단)
+        List<EvaluationSummary> evaluationSummaries, // 가장 많이 소비한 마음
+        List<EmotionDetailSummary> emotionDetails, // 그아래로 전체 마음 순위별 요약 리스트(감정별 만족도 분포 포함)
+        List<ExpenseSimpleResponse> top3Expenses,
+        long emotionTotalAmount, // 마음 당 총 소비건수
+        long monthlyTotalCount, // 월간 총 소비개수
+        long monthlyTotalAmount// 월간 총 소비금액
+
+){}

--- a/src/main/java/com/nitrogen/domain/expense/dto/report/detail/remind_grouping_expenselist/MonthlyExpenseDetailResponse.java
+++ b/src/main/java/com/nitrogen/domain/expense/dto/report/detail/remind_grouping_expenselist/MonthlyExpenseDetailResponse.java
@@ -1,0 +1,11 @@
+package com.nitrogen.domain.expense.dto.report.detail.remind_grouping_expenselist;
+
+import java.util.List;
+
+public record MonthlyExpenseDetailResponse(
+        String monthTitle,         // 2026년 1월
+        String emotionTitle,       // 홀린 듯한 소비 상세 내역
+        int totalCount,            // 총 소비 8건
+        long totalAmount,          // 총 9,999,000원
+        List<EvaluationGroupResponse> evaluationGroups // 만족도별 그룹 리스트
+) {}

--- a/src/main/java/com/nitrogen/domain/expense/service/report/MonthlyDetailRecordService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/report/MonthlyDetailRecordService.java
@@ -102,6 +102,10 @@ public class MonthlyDetailRecordService {
                 .filter(e -> e.getEmotionType() == topEmotion)
                 .mapToLong(Expense::getAmount).sum();
 
+        long topEmotionCount = allExpenses.stream()
+                .filter(e -> e.getEmotionType() == topEmotion)
+                .count();
+
         long monthlyTotalAmount = allExpenses.stream().mapToLong(Expense::getAmount).sum();
 
         List<ExpenseSimpleResponse> top3Response = top3Expenses.stream()
@@ -115,7 +119,7 @@ public class MonthlyDetailRecordService {
                 start.format(fmt),
                 end.format(fmt),
                 emotionFeedbackMessage,
-                new EmotionSummary(topEmotion.getEmotion_description(), topEmotionTotalAmount, (long) top3Expenses.size(), emotionFeedbackMessage),
+                new EmotionSummary(topEmotion.getEmotion_description(), topEmotionTotalAmount, topEmotionCount, emotionFeedbackMessage),
                 evaluationFeedbackMessage,
                 evaluationSummaries,
                 emotionDetails,

--- a/src/main/java/com/nitrogen/domain/expense/service/report/MonthlyDetailRecordService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/report/MonthlyDetailRecordService.java
@@ -1,0 +1,129 @@
+package com.nitrogen.domain.expense.service.report;
+
+import com.nitrogen.domain.expense.dto.report.summary.EmotionSummary;
+import com.nitrogen.domain.expense.dto.report.summary.EvaluationSummary;
+import com.nitrogen.domain.expense.dto.report.detail.ExpenseSimpleResponse;
+import com.nitrogen.domain.expense.dto.report.detail.MonthlyDetailReportResponse;
+import com.nitrogen.domain.expense.dto.report.summary.EmotionDetailSummary;
+import com.nitrogen.domain.expense.entity.Expense;
+import com.nitrogen.domain.expense.entity.enums.EmotionType;
+import com.nitrogen.domain.expense.entity.enums.EvaluationFeedback;
+import com.nitrogen.domain.expense.entity.enums.EvaluationType;
+import com.nitrogen.domain.expense.repository.ExpenseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyDetailRecordService {
+    private final ExpenseRepository expenseRepository;
+
+    public MonthlyDetailReportResponse generateMonthlyDetailReport(Long userId, LocalDate start, LocalDate end, String monthTitle) {
+
+        // {월간 총 소비 금액}
+        List<Expense> allExpenses = expenseRepository.findAllByUserIdAndExpendedAtBetweenWithCategory(userId, start, end);
+
+        // 이번 달 가장 빈번했던 {마음항목} 선정
+        EmotionType topEmotion = allExpenses.stream()
+                .collect(Collectors.groupingBy(Expense::getEmotionType, Collectors.counting()))
+                .entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(EmotionType.TYPE_B);
+
+        // 상단: 가장 많은 마음항목의 소비회고 완료 건에 대한 만족도 평균점수
+        double topEmotionAvgScore = allExpenses.stream()
+                .filter(e -> e.getEmotionType() == topEmotion)
+                .filter(e -> e.getEvaluationType() != null)
+                .mapToDouble(e -> e.getEvaluationType().getScore())
+                .average()
+                .orElse(0.0);
+
+        // 하단: 전체 월간 만족도 평균점수
+        double avgScore = expenseRepository.calculateAverageSatisfactionScore(userId, start, end);
+
+        long seed = Objects.hash(userId, start);
+        String emotionFeedbackMessage = EvaluationFeedback.getRandomSentence(topEmotionAvgScore, seed); // 상단 (가장 많은 마음항목 기준)
+        String evaluationFeedbackMessage = EvaluationFeedback.getRandomSentence(avgScore, seed); // 하단 (전체 월간 기준)
+
+        // 각 만족도별 소비 건수와 총액 - 중앙 리스트 UI
+        List<EvaluationSummary> evaluationSummaries = Arrays.stream(EvaluationType.values())
+                .map(type -> new EvaluationSummary(
+                        type,
+                        allExpenses.stream().filter(e -> e.getEvaluationType() == type).count(),
+                        allExpenses.stream().filter(e -> e.getEvaluationType() == type).mapToLong(Expense::getAmount).sum()
+                )).toList();
+
+        // 선정된 {마음항목} 내에서 가장 비싼 지출 3건 조회
+        List<Expense> top3Expenses = expenseRepository.findTop3ByEmotion(userId, start, end, topEmotion.name());
+
+        /*
+        금액 내림차순 > 건수 내림차순 > 이름 오름차순
+        */
+        Map<EmotionType, List<Expense>> emotionGrouped = allExpenses.stream()
+                .collect(Collectors.groupingBy(Expense::getEmotionType));
+
+        List<EmotionDetailSummary> emotionDetails = emotionGrouped.entrySet().stream()
+                .map(entry -> {
+                    List<Expense> emotionExpenses = entry.getValue();
+                    double emotionAvgScore = emotionExpenses.stream()
+                            .filter(e -> e.getEvaluationType() != null)
+                            .mapToDouble(e -> e.getEvaluationType().getScore())
+                            .average()
+                            .orElse(0.0);
+
+                    List<EvaluationSummary> perEmotionEvalSummaries = Arrays.stream(EvaluationType.values())
+                            .map(type -> new EvaluationSummary(
+                                    type,
+                                    emotionExpenses.stream().filter(e -> e.getEvaluationType() == type).count(),
+                                    emotionExpenses.stream().filter(e -> e.getEvaluationType() == type).mapToLong(Expense::getAmount).sum()
+                            )).toList();
+
+                    return new EmotionDetailSummary(
+                            entry.getKey().getEmotion_description(),
+                            emotionExpenses.stream().mapToLong(Expense::getAmount).sum(),
+                            emotionExpenses.size(),
+                            EvaluationFeedback.getRandomSentence(emotionAvgScore, seed),
+                            perEmotionEvalSummaries
+                    );
+                })
+                .sorted(Comparator.comparingLong(EmotionDetailSummary::totalAmount).reversed()
+                                .thenComparing(Comparator.comparingLong(EmotionDetailSummary::count).reversed())
+                        .thenComparing(EmotionDetailSummary::emotionDescription))
+                .toList();
+
+        // 가장 많이 소비한 마음의 총액과 월간 전체 소비 총액 계산
+        long topEmotionTotalAmount = allExpenses.stream()
+                .filter(e -> e.getEmotionType() == topEmotion)
+                .mapToLong(Expense::getAmount).sum();
+
+        long monthlyTotalAmount = allExpenses.stream().mapToLong(Expense::getAmount).sum();
+
+        List<ExpenseSimpleResponse> top3Response = top3Expenses.stream()
+                .map(e -> new ExpenseSimpleResponse(e.getUsageHistory(), e.getAmount()))
+                .toList();
+
+        DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+        return new MonthlyDetailReportResponse(
+                monthTitle,
+                start.format(fmt),
+                end.format(fmt),
+                emotionFeedbackMessage,
+                new EmotionSummary(topEmotion.getEmotion_description(), topEmotionTotalAmount, (long) top3Expenses.size(), emotionFeedbackMessage),
+                evaluationFeedbackMessage,
+                evaluationSummaries,
+                emotionDetails,
+                top3Response,
+                topEmotionTotalAmount,
+                (long) allExpenses.size(),
+                monthlyTotalAmount
+        );
+    }
+
+}

--- a/src/main/java/com/nitrogen/domain/expense/service/report/TotalOpenStatusService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/report/TotalOpenStatusService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.time.temporal.WeekFields;
 import java.util.ArrayList;
@@ -24,13 +25,15 @@ public class TotalOpenStatusService {
     public TotalOpenStatusResponse getTotalOpenStatus(Long userId, int year, int month) {
         LocalDate startOfMonth = LocalDate.of(year, month, 1);
         LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
-        LocalDate now = LocalDate.now();
+        LocalDateTime nowDateTime = LocalDateTime.now();
+        LocalDate now = nowDateTime.toLocalDate();
 
         // 월간 총액
         long totalAmount = expenseRepository.calculateMonthlyTotal(userId, startOfMonth, endOfMonth);
 
-        // 월간 리포트 오픈 여부 (다음달 1일 이후)
-        boolean monthlyIsOpened = !now.isBefore(startOfMonth.plusMonths(1));
+        // 월간 리포트 오픈 여부 (다음달 1일 오전 8시 이후)
+        LocalDateTime monthlyOpenDateTime = startOfMonth.plusMonths(1).atTime(8, 0);
+        boolean monthlyIsOpened = !nowDateTime.isBefore(monthlyOpenDateTime);
 
         // 주차별 오픈 상태
         List<WeeklyOpenStatus> weeklyReports = new ArrayList<>();

--- a/src/main/java/com/nitrogen/domain/expense/service/report/WeeklyDetailRecordService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/report/WeeklyDetailRecordService.java
@@ -102,6 +102,10 @@ public class WeeklyDetailRecordService {
                 .filter(e -> e.getEmotionType() == topEmotion)
                 .mapToLong(Expense::getAmount).sum();
 
+        long topEmotionCount = allExpenses.stream()
+                .filter(e -> e.getEmotionType() == topEmotion)
+                .count();
+
         long weeklyTotalAmount = allExpenses.stream().mapToLong(Expense::getAmount).sum();
 
         List<ExpenseSimpleResponse> top3Response = top3Expenses.stream()
@@ -115,7 +119,7 @@ public class WeeklyDetailRecordService {
                 start.format(fmt),
                 end.format(fmt),
                 emotionFeedbackMessage,
-                new EmotionSummary(topEmotion.getEmotion_description(), topEmotionTotalAmount, (long) top3Expenses.size(), emotionFeedbackMessage),
+                new EmotionSummary(topEmotion.getEmotion_description(), topEmotionTotalAmount, topEmotionCount, emotionFeedbackMessage),
                 evaluationFeedbackMessage,
                 evaluationSummaries,
                 emotionDetails,

--- a/src/main/java/com/nitrogen/domain/expense/service/report/remind_grouping_expenselist/MonthlyExpenseDetailService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/report/remind_grouping_expenselist/MonthlyExpenseDetailService.java
@@ -1,0 +1,78 @@
+package com.nitrogen.domain.expense.service.report.remind_grouping_expenselist;
+
+import com.nitrogen.domain.expense.dto.report.detail.remind_grouping_expenselist.EvaluationGroupResponse;
+import com.nitrogen.domain.expense.dto.report.detail.remind_grouping_expenselist.ExpenseItemResponse;
+import com.nitrogen.domain.expense.dto.report.detail.remind_grouping_expenselist.MonthlyExpenseDetailResponse;
+import com.nitrogen.domain.expense.entity.Expense;
+import com.nitrogen.domain.expense.entity.enums.EmotionType;
+import com.nitrogen.domain.expense.entity.enums.EvaluationType;
+import com.nitrogen.domain.expense.repository.ExpenseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyExpenseDetailService {
+
+    private final ExpenseRepository expenseRepository;
+
+    // 선택한 마음항목에 해당하는 지출만 필터링한뒤 그 안에서 회고별로 소비 상세 내역 조회
+    public MonthlyExpenseDetailResponse getMonthlyExpenseDetailList(Long userId, int year, int month, EmotionType emotionType) {
+
+        // year/month 기반으로 월 범위, monthTitle 자동 생성
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+        String monthTitle = String.format("%d년 %d월", year, month);
+
+        List<Expense> allExpenses = expenseRepository.findAllByUserIdAndExpendedAtBetweenWithCategory(userId, start, end);
+
+        List<Expense> filteredExpenses = allExpenses.stream()
+                .filter(e -> e.getEmotionType() == emotionType)
+                .toList();
+
+        long totalAmount = filteredExpenses.stream().mapToLong(Expense::getAmount).sum();
+        int totalCount = filteredExpenses.size();
+
+        AtomicInteger stepCounter = new AtomicInteger(1);
+
+        List<EvaluationGroupResponse> evaluationGroups = Arrays.stream(EvaluationType.values())
+                .map(type -> {
+                    List<ExpenseItemResponse> items = filteredExpenses.stream()
+                            .filter(e -> e.getEvaluationType() == type)
+                            .map(e -> new ExpenseItemResponse(
+                                    e.getUsageHistory(),
+                                    e.getCategory().getName(),
+                                    e.getAmount()
+                            ))
+                            .toList();
+
+                    if (items.isEmpty()) return null;
+
+                    return new EvaluationGroupResponse(
+                            stepCounter.getAndIncrement(),
+                            type.getEvaluation_description(),
+                            items.size(),
+                            items.stream().mapToLong(ExpenseItemResponse::amount).sum(),
+                            items
+                    );
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        String emotionTitle = String.format("%s 소비 상세 내역", emotionType.getEmotion_description());
+
+        return new MonthlyExpenseDetailResponse(
+                monthTitle,
+                emotionTitle,
+                totalCount,
+                totalAmount,
+                evaluationGroups
+        );
+    }
+}

--- a/src/main/java/com/nitrogen/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/nitrogen/global/apiPayload/code/status/ErrorStatus.java
@@ -11,7 +11,8 @@ public enum ErrorStatus {
     INVALID_TOKEN("TOKEN4003", "잘못된 토큰입니다."),
     EXPENSE_FORBIDDEN("EXP403", "해당 지출 내역에 대한 권한이 없습니다."),
     EXPENSE_NOT_FOUND("EXP404", "해당 지출 내역을 찾을 수 없습니다."),
-    INVALID_ONBOARDING_TYPE("EXP405", "유효하지 않은 온보딩 유형입니다.");
+    INVALID_ONBOARDING_TYPE("EXP405", "유효하지 않은 온보딩 유형입니다."),
+    MONTHLY_REPORT_NOT_OPENED("EXP406", "월간 분석 리포트가 아직 열리지 않았습니다.");
 
 
     private final String code;


### PR DESCRIPTION
## Related issue 🛠

resolved #25

## 작업 내용 ✏️

* 월간 분석 상세 리포트 API (`GET /api/expense/monthly_detail`) 신규 구현
* 월간 소비 내역 상세 API (`GET /api/monthly-reports/details`) 신규 구현
* 기존 주간 리포트 API 구조와 **완전 동일하게 1:1 미러링 설계**
* 월간 리포트 **오픈 시점 가드 로직 추가**
  → 다음 달 1일 오전 8시 이후에만 조회 가능
* `topEmotion.count` 잘못된 매핑 버그 수정
  → top3 개수(최대 3)가 아닌 실제 감정 전체 count로 수정 (weekly + monthly 공통 반영)

## 변경 사항 📋
* [x] ✨ Feature Feature

## 체크리스트 ✅

* [x] PR 컨벤션에 맞게 작성했습니다.
* [x] Commit 메시지 컨벤션을 지켰습니다.
* [x] Issue 번호에 맞는 브랜치를 생성했습니다.
* [x] Issue 컨벤션에 맞게 Issue를 생성했습니다.
* [x] 로컬 테스트 완료했습니다. (로컬 스웨거 정상 요청 확인)

## 리뷰어에게 📢

### 1. 설계 의도

* 월간 리포트는 주간 리포트와 **완전히 동일한 응답 구조**로 설계했습니다.
* 프론트에서 별도 분기 없이 기존 VM 변환 로직을 그대로 재사용할 수 있도록
  → 필드명 / 정렬 기준 / 직렬화 형태까지 모두 맞췄습니다. 

---

### 2. 오픈 시점 로직

* 월간 리포트는 **배치 기반 데이터**이기 때문에
  → `다음 달 1일 08:00` 이후에만 조회 가능하도록 제한했습니다. 
* 오픈 전 요청 시
  → `EXP406 (MONTHLY_REPORT_NOT_OPENED)` 에러 반환합니다.

---

### 3. 버그 수정

* 기존 로직에서

  ```
  topEmotion.count = top3Expenses.size()
  ```

  로 잘못 매핑되어 있던 문제 수정했습니다.

* 현재는
  → **해당 감정의 실제 전체 count** 기준으로 반환하도록 변경했습니다.

* 이 값은 프론트에서
  → "총 N건" 표시 등에 사용되므로 영향도 있는 부분입니다.

---

### 4. 프론트 연동 포인트

* 월간 상세 / 주간 상세 모두 동일 VM 사용 가능
* 에러 응답 구조 주의

  * 성공: `{ isSuccess, result }`
  * 실패: `{ code, message }` (isSuccess 없음)

---

### 5. 확인 요청

* 월간 리포트 오픈 시간 (08:00) 기준 괜찮은지
* 에러 코드 (`EXP406`) 네이밍/레벨 적절한지
* weekly / monthly 완전 대칭 구조 유지 방향 문제 없는지