### PR TITLE
♻️ Refactor 조회 로직 성능 개선 (N+1 제거 및 인메모리 반복 최적화)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,35 @@
-## Copyright Notice & Contribution Scope
+## 🌿 브랜치 전략(반드시 확인하세요)
 
-This repository contains the backend server source code for the **Monit** application.
+| 브랜치 | 용도 | 직접 push |
+|--------|------|-----------|
+| `develop` | 운영 브랜치 | ❌ 금지 |
+| `feature/apple-login-split ` | 기능 개발 브랜치 | ✅ 가능 |
 
-* The author of this repository contributed to the **server-side implementation** of the Monit service.
-* The copyright registration submitted for this project applies **only to the server-side source code included in this repository**.
-* Other components of the Monit application (such as mobile client, UI/UX design, or external services) are **not included in this copyright registration unless explicitly stated**.
+---
 
-© 2026 Jaeyun. All rights reserved.
+## 🔄 작업 플로우
+
+1. `feature/기능명` 브랜치 생성 후 작업
+2. 원격에 push
+```bash
+   git push origin feature/apple-login-split
+```
+3. GitHub Actions CI/CD 확인
+4. GitHub에서 `develop`으로 PR 생성
+5. 관리자 승인 후 merge
+6. 로컬 `develop` 동기화
+```bash
+   git checkout develop
+   git pull origin develop
+```
+
+---
+
+## ⚠️ 주의사항
+
+- `develop` 브랜치 직접 push **금지**
+- merge 후 **`Delete branch` 버튼 클릭 절대 금지** (테스트 서버 연결된 브랜치)
+- force push **금지**
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | 브랜치 | 용도 | 직접 push |
 |--------|------|-----------|
 | `develop` | 운영 브랜치 | ❌ 금지 |
-| `feature/apple-login-split ` | 기능 개발 브랜치 | ✅ 가능 |
+| `feature/apple-login-split ` | 통합테스트 브랜치 | ✅ 가능 |
 
 ---
 
@@ -12,12 +12,13 @@
 1. `feature/기능명` 브랜치 생성 후 작업
 2. 원격에 push
 ```bash
-   git push origin feature/apple-login-split
+   git push origin feature/<기능명>
 ```
-3. GitHub Actions CI/CD 확인
-4. GitHub에서 `develop`으로 PR 생성
-5. 관리자 승인 후 merge
-6. 로컬 `develop` 동기화
+3. 통합테스트에 PR
+4. GitHub Actions CI/CD 확인
+5. GitHub에서 `develop`으로 PR 생성
+6. 관리자 승인 후 merge
+7. 로컬 `develop` 동기화
 ```bash
    git checkout develop
    git pull origin develop
@@ -28,7 +29,7 @@
 ## ⚠️ 주의사항
 
 - `develop` 브랜치 직접 push **금지**
-- merge 후 **`Delete branch` 버튼 클릭 절대 금지** (테스트 서버 연결된 브랜치)
+- 통합테스트 -> 운영으로 merge 후 **`Delete branch` 버튼 클릭 절대 금지** (테스트 서버 연결된 브랜치)
 - force push **금지**
 
 <br>

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,11 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    testLogging {
+        events "passed", "failed", "skipped"
+        showStandardStreams = true
+        exceptionFormat = "full"
+    }
 }
 
 jar {

--- a/src/main/java/com/nitrogen/domain/expense/dto/calendar/MonthlyAmountDTO.java
+++ b/src/main/java/com/nitrogen/domain/expense/dto/calendar/MonthlyAmountDTO.java
@@ -1,0 +1,6 @@
+package com.nitrogen.domain.expense.dto.calendar;
+
+public record MonthlyAmountDTO(
+        String month,
+        Long totalAmount
+) {}

--- a/src/main/java/com/nitrogen/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/nitrogen/domain/expense/repository/ExpenseRepository.java
@@ -1,6 +1,7 @@
 package com.nitrogen.domain.expense.repository;
 
 import com.nitrogen.domain.expense.dto.calendar.DailyAmountDTO;
+import com.nitrogen.domain.expense.dto.calendar.MonthlyAmountDTO;
 import com.nitrogen.domain.expense.entity.Expense;
 import com.nitrogen.domain.expense.entity.enums.EmotionType;
 import com.nitrogen.domain.expense.entity.enums.EvaluationType;
@@ -78,6 +79,14 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
             "FROM Expense e WHERE e.user.userId = :userId " +
             "ORDER BY e.expendedAt DESC")
     List<String> findDistinctMonthsByUserId(@Param("userId") Long userId);
+
+    // 사용자의 월별 지출 합계 조회 (월 목록 + 합계를 한 번에)
+    @Query("SELECT new com.nitrogen.domain.expense.dto.calendar.MonthlyAmountDTO(" +
+            "FUNCTION('DATE_FORMAT', e.expendedAt, '%Y-%m-01'), SUM(e.amount)) " +
+            "FROM Expense e WHERE e.user.userId = :userId " +
+            "GROUP BY FUNCTION('DATE_FORMAT', e.expendedAt, '%Y-%m-01') " +
+            "ORDER BY FUNCTION('DATE_FORMAT', e.expendedAt, '%Y-%m-01') DESC")
+    List<MonthlyAmountDTO> findMonthlyTotalsByUserId(@Param("userId") Long userId);
 
     // 유저의 지출 중 오늘 이전 날짜이면서 아직 평가가 되지 않은 것이 있는지 확인
     boolean existsByEvaluationTypeIsNullAndUserAndExpendedAtBefore(User user, LocalDate date);

--- a/src/main/java/com/nitrogen/domain/expense/service/inquiry/ExpenseInquiryService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/inquiry/ExpenseInquiryService.java
@@ -2,6 +2,7 @@ package com.nitrogen.domain.expense.service.inquiry;
 
 import com.nitrogen.domain.expense.dto.calendar.CalendarResponseDTO;
 import com.nitrogen.domain.expense.dto.calendar.DailyAmountDTO;
+import com.nitrogen.domain.expense.dto.calendar.MonthlyAmountDTO;
 import com.nitrogen.domain.expense.dto.expense.DailyExpenseResponseDTO;
 import com.nitrogen.domain.expense.dto.expense.ExpenseListDTO;
 import com.nitrogen.domain.expense.dto.expense.ExpenseResponseDTO;
@@ -118,23 +119,19 @@ public class ExpenseInquiryService {
     // 월별 총액 리스트
     @Transactional(readOnly = true)
     public List<MonthlyReportSummaryResponse> getMonthlyTotalList(Long userId) {
-        List<String> monthsWithExpenses = expenseRepository.findDistinctMonthsByUserId(userId);
+        List<MonthlyAmountDTO> monthlyTotals = expenseRepository.findMonthlyTotalsByUserId(userId);
         LocalDate now = LocalDate.now();
 
-        return monthsWithExpenses.stream()
-                .map(monthStr -> {
-                    LocalDate startOfMonth = LocalDate.parse(monthStr);
-                    LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
-
-                    long totalAmount = expenseRepository.calculateMonthlyTotal(userId, startOfMonth, endOfMonth);
-
+        return monthlyTotals.stream()
+                .map(dto -> {
+                    LocalDate startOfMonth = LocalDate.parse(dto.month());
                     LocalDate reportOpenDate = startOfMonth.plusMonths(1);
                     boolean isOpened = !now.isBefore(reportOpenDate); // now.isAfter(reportOpenDate) || now.isEqual(reportOpenDate);
 
                     return new MonthlyReportSummaryResponse(
                             String.valueOf(startOfMonth.getYear() % 100), // 2026 -> 26 변환
                             String.valueOf(startOfMonth.getMonthValue()),
-                            totalAmount,
+                            dto.totalAmount(),
                             isOpened
                     );
                 })

--- a/src/main/java/com/nitrogen/domain/expense/service/report/MonthlyDetailRecordService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/report/MonthlyDetailRecordService.java
@@ -52,12 +52,15 @@ public class MonthlyDetailRecordService {
         String evaluationFeedbackMessage = EvaluationFeedback.getRandomSentence(avgScore, seed); // 하단 (전체 월간 기준)
 
         // 각 만족도별 소비 건수와 총액 - 중앙 리스트 UI
+        Map<EvaluationType, List<Expense>> evalGrouped = allExpenses.stream()
+                .filter(e -> e.getEvaluationType() != null)
+                .collect(Collectors.groupingBy(Expense::getEvaluationType));
+
         List<EvaluationSummary> evaluationSummaries = Arrays.stream(EvaluationType.values())
-                .map(type -> new EvaluationSummary(
-                        type,
-                        allExpenses.stream().filter(e -> e.getEvaluationType() == type).count(),
-                        allExpenses.stream().filter(e -> e.getEvaluationType() == type).mapToLong(Expense::getAmount).sum()
-                )).toList();
+                .map(type ->{
+                    List<Expense> group = evalGrouped.getOrDefault(type, List.of());
+                    return new EvaluationSummary(type, group.size(), group.stream().mapToLong(Expense::getAmount).sum());
+                }).toList();
 
         // 선정된 {마음항목} 내에서 가장 비싼 지출 3건 조회
         List<Expense> top3Expenses = expenseRepository.findTop3ByEmotion(userId, start, end, topEmotion.name());
@@ -77,12 +80,15 @@ public class MonthlyDetailRecordService {
                             .average()
                             .orElse(0.0);
 
+                    Map<EvaluationType, List<Expense>> perEmotionEvalGrouped = emotionExpenses.stream()
+                            .filter(e -> e.getEvaluationType() != null)
+                            .collect(Collectors.groupingBy(Expense::getEvaluationType));
+
                     List<EvaluationSummary> perEmotionEvalSummaries = Arrays.stream(EvaluationType.values())
-                            .map(type -> new EvaluationSummary(
-                                    type,
-                                    emotionExpenses.stream().filter(e -> e.getEvaluationType() == type).count(),
-                                    emotionExpenses.stream().filter(e -> e.getEvaluationType() == type).mapToLong(Expense::getAmount).sum()
-                            )).toList();
+                            .map(type -> {
+                                List<Expense> group = perEmotionEvalGrouped.getOrDefault(type, List.of());
+                                return new EvaluationSummary(type, group.size(), group.stream().mapToLong(Expense::getAmount).sum());
+                            }).toList();
 
                     return new EmotionDetailSummary(
                             entry.getKey().getEmotion_description(),
@@ -97,14 +103,10 @@ public class MonthlyDetailRecordService {
                         .thenComparing(EmotionDetailSummary::emotionDescription))
                 .toList();
 
-        // 가장 많이 소비한 마음의 총액과 월간 전체 소비 총액 계산
-        long topEmotionTotalAmount = allExpenses.stream()
-                .filter(e -> e.getEmotionType() == topEmotion)
-                .mapToLong(Expense::getAmount).sum();
-
-        long topEmotionCount = allExpenses.stream()
-                .filter(e -> e.getEmotionType() == topEmotion)
-                .count();
+        // 가장 많이 소비한 {마음항목}의 총액과 월간 전체 소비 총액 계산
+        List<Expense> topEmotionExpenses = emotionGrouped.getOrDefault(topEmotion, List.of());
+        long topEmotionTotalAmount = topEmotionExpenses.stream().mapToLong(Expense::getAmount).sum();
+        long topEmotionCount = topEmotionExpenses.size();
 
         long monthlyTotalAmount = allExpenses.stream().mapToLong(Expense::getAmount).sum();
 

--- a/src/main/java/com/nitrogen/domain/expense/service/report/WeeklyDetailRecordService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/report/WeeklyDetailRecordService.java
@@ -52,12 +52,15 @@ public class WeeklyDetailRecordService {
         String evaluationFeedbackMessage = EvaluationFeedback.getRandomSentence(avgScore, seed); // 하단 (전체 주간 기준)
 
         // 각 만족도별 소비 건수와 총액 - 중앙 리스트 UI
+        Map<EvaluationType, List<Expense>> evalGrouped = allExpenses.stream()
+                .filter(e -> e.getEvaluationType() != null)
+                .collect(Collectors.groupingBy(Expense::getEvaluationType));
+
         List<EvaluationSummary> evaluationSummaries = Arrays.stream(EvaluationType.values())
-                .map(type -> new EvaluationSummary(
-                        type,
-                        allExpenses.stream().filter(e -> e.getEvaluationType() == type).count(),
-                        allExpenses.stream().filter(e -> e.getEvaluationType() == type).mapToLong(Expense::getAmount).sum()
-                )).toList();
+                .map(type ->{
+                    List<Expense> group = evalGrouped.getOrDefault(type, List.of());
+                    return new EvaluationSummary(type, group.size(), group.stream().mapToLong(Expense::getAmount).sum());
+                }).toList();
 
         // 선정된 {마음항목} 내에서 가장 비싼 지출 3건 조회
         List<Expense> top3Expenses = expenseRepository.findTop3ByEmotion(userId, start, end, topEmotion.name());
@@ -77,12 +80,15 @@ public class WeeklyDetailRecordService {
                             .average()
                             .orElse(0.0);
 
+                    Map<EvaluationType, List<Expense>> perEmotionEvalGrouped = emotionExpenses.stream()
+                            .filter(e -> e.getEvaluationType() != null)
+                            .collect(Collectors.groupingBy(Expense::getEvaluationType));
+
                     List<EvaluationSummary> perEmotionEvalSummaries = Arrays.stream(EvaluationType.values())
-                            .map(type -> new EvaluationSummary(
-                                    type,
-                                    emotionExpenses.stream().filter(e -> e.getEvaluationType() == type).count(),
-                                    emotionExpenses.stream().filter(e -> e.getEvaluationType() == type).mapToLong(Expense::getAmount).sum()
-                            )).toList();
+                            .map(type -> {
+                                List<Expense> group = perEmotionEvalGrouped.getOrDefault(type, List.of());
+                                return new EvaluationSummary(type, group.size(), group.stream().mapToLong(Expense::getAmount).sum());
+                            }).toList();
 
                     return new EmotionDetailSummary(
                             entry.getKey().getEmotion_description(),
@@ -98,13 +104,9 @@ public class WeeklyDetailRecordService {
                 .toList();
 
         // 가장 많이 소비한 마음의 총액과 주간 전체 소비 총액 계산
-        long topEmotionTotalAmount = allExpenses.stream()
-                .filter(e -> e.getEmotionType() == topEmotion)
-                .mapToLong(Expense::getAmount).sum();
-
-        long topEmotionCount = allExpenses.stream()
-                .filter(e -> e.getEmotionType() == topEmotion)
-                .count();
+        List<Expense> topEmotionExpenses = emotionGrouped.getOrDefault(topEmotion, List.of());
+        long topEmotionTotalAmount = topEmotionExpenses.stream().mapToLong(Expense::getAmount).sum();
+        long topEmotionCount = topEmotionExpenses.size();
 
         long weeklyTotalAmount = allExpenses.stream().mapToLong(Expense::getAmount).sum();
 

--- a/src/main/java/com/nitrogen/domain/expense/service/report/WeeklyRecordService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/report/WeeklyRecordService.java
@@ -51,8 +51,6 @@ public class WeeklyRecordService {
                     boolean isArrived = !now.isBefore(reportOpenDate);
                     if (!isArrived) return null;
 
-                    LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
-                    long totalAmount = expenseRepository.calculateMonthlyTotal(userId, startOfMonth, endOfMonth);
                     boolean isChecked = checkedMonths.contains(startOfMonth);
 
                     return new MonthlyReportArrivalResponse(

--- a/src/main/java/com/nitrogen/domain/expense/service/report/WeeklyRecordService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/report/WeeklyRecordService.java
@@ -1,5 +1,6 @@
 package com.nitrogen.domain.expense.service.report;
 
+import com.nitrogen.domain.expense.dto.calendar.MonthlyAmountDTO;
 import com.nitrogen.domain.expense.dto.report.summary.EmotionSummary;
 import com.nitrogen.domain.expense.dto.report.summary.MonthlyReportArrivalResponse;
 import com.nitrogen.domain.expense.dto.report.summary.WeeklyReportResponse;
@@ -35,7 +36,7 @@ public class WeeklyRecordService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
 
         LocalDate now = LocalDate.now();
-        List<String> monthsWithExpenses = expenseRepository.findDistinctMonthsByUserId(userId);
+        List<MonthlyAmountDTO> monthsWithExpenses = expenseRepository.findMonthlyTotalsByUserId(userId);
 
         // 유저가 확인한 월 목록
         Set<LocalDate> checkedMonths = monthlyReportReadRepository.findAllByUser(user).stream()
@@ -43,8 +44,8 @@ public class WeeklyRecordService {
                 .collect(Collectors.toSet());
 
         return monthsWithExpenses.stream()
-                .map(monthStr -> {
-                    LocalDate startOfMonth = LocalDate.parse(monthStr);
+                .map(dto -> {
+                    LocalDate startOfMonth = LocalDate.parse(dto.month());
                     LocalDate reportOpenDate = startOfMonth.plusMonths(1);
 
                     // 다음달 1일이 지나야 리포트가 "도착"한 상태

--- a/src/test/java/com/nitrogen/domain/expense/service/inquiry/ExpenseInquiryServiceTest.java
+++ b/src/test/java/com/nitrogen/domain/expense/service/inquiry/ExpenseInquiryServiceTest.java
@@ -1,0 +1,113 @@
+package com.nitrogen.domain.expense.service.inquiry;
+
+import com.nitrogen.domain.expense.dto.calendar.MonthlyAmountDTO;
+import com.nitrogen.domain.expense.dto.report.summary.MonthlyReportSummaryResponse;
+import com.nitrogen.domain.expense.repository.ExpenseRepository;
+import com.nitrogen.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ExpenseInquiryServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    ExpenseRepository expenseRepository;
+    @InjectMocks
+    ExpenseInquiryService expenseInquiryService;
+
+    @Test
+    @DisplayName("N+1 유발 메서드를 사용하지 않고 단일 쿼리 방식으로 조회한다")
+    void getMonthlyTotalList_단일_쿼리로_조회() {
+        // given
+        Long userId = 1L;
+        int monthCount = 3;
+        List<MonthlyAmountDTO> mockData = List.of(
+                new MonthlyAmountDTO("2026-03-01", 150000L),
+                new MonthlyAmountDTO("2026-02-01", 200000L),
+                new MonthlyAmountDTO("2026-01-01", 100000L)
+        );
+        when(expenseRepository.findMonthlyTotalsByUserId(userId)).thenReturn(mockData);
+
+        // when
+        List<MonthlyReportSummaryResponse> result = expenseInquiryService.getMonthlyTotalList(userId);
+
+        // then — 쿼리 횟수 검증
+        verify(expenseRepository, times(1)).findMonthlyTotalsByUserId(userId);
+        verify(expenseRepository, never()).findDistinctMonthsByUserId(anyLong());
+        verify(expenseRepository, never()).calculateMonthlyTotal(anyLong(), any(), any());
+
+        System.out.println("=== N+1 쿼리 해소 검증 ===");
+        System.out.println("테스트 월 수: " + monthCount + "개월");
+        System.out.println("[개선 전] 예상 쿼리 수: " + (1 + monthCount) + "회 (findDistinctMonths 1회 + calculateMonthlyTotal " + monthCount + "회)");
+        System.out.println("[개선 후] 실제 쿼리 수: 1회 (findMonthlyTotalsByUserId 1회)");
+        System.out.println("findMonthlyTotalsByUserId 호출: 1회 — OK");
+        System.out.println("findDistinctMonthsByUserId 호출: 0회 — OK");
+        System.out.println("calculateMonthlyTotal    호출: 0회 — OK");
+    }
+
+    @Test
+    @DisplayName("월별 총액 리스트 DTO 매핑이 정확하다")
+    void getMonthlyTotalList_DTO_매핑_정합성() {
+        // given
+        Long userId = 1L;
+        List<MonthlyAmountDTO> mockData = List.of(
+                new MonthlyAmountDTO("2026-03-01", 150000L),
+                new MonthlyAmountDTO("2026-01-01", 100000L)
+        );
+
+        when(expenseRepository.findMonthlyTotalsByUserId(userId)).thenReturn(mockData);
+
+        // when
+        List<MonthlyReportSummaryResponse> result = expenseInquiryService.getMonthlyTotalList(userId);
+
+        // then
+        assertEquals(2, result.size());
+
+        MonthlyReportSummaryResponse march = result.get(0);
+        assertEquals("26", march.year());
+        assertEquals("3", march.month());
+        assertEquals(150000L, march.totalAmount());
+
+        MonthlyReportSummaryResponse january = result.get(1);
+        assertEquals("26", january.year());
+        assertEquals("1", january.month());
+        assertEquals(100000L, january.totalAmount());
+
+        System.out.println("=== DTO 매핑 정합성 검증 ===");
+        for (MonthlyReportSummaryResponse r : result) {
+            System.out.printf("  %s년 %s월 → totalAmount: %,d원, isOpened: %s%n",
+                    r.year(), r.month(), r.totalAmount(), r.isOpened());
+        }
+    }
+
+    @Test
+    @DisplayName("지출 기록이 없으면 빈 리스트를 반환한다")
+    void getMonthlyTotalList_지출없으면_빈리스트() {
+        // given
+        Long userId = 1L;
+        when(expenseRepository.findMonthlyTotalsByUserId(userId)).thenReturn(List.of());
+
+        // when
+        List<MonthlyReportSummaryResponse> result = expenseInquiryService.getMonthlyTotalList(userId);
+
+        // then
+        assertTrue(result.isEmpty());
+        verify(expenseRepository, times(1)).findMonthlyTotalsByUserId(userId);
+        verify(expenseRepository, never()).calculateMonthlyTotal(anyLong(), any(), any());
+
+        System.out.println("=== 빈 데이터 검증 ===");
+        System.out.println("반환 결과: " + result.size() + "건 (빈 리스트)");
+        System.out.println("불필요한 쿼리 호출: 0회 — OK");
+    }
+}


### PR DESCRIPTION
## 🚀 조회 로직 성능 개선 (N+1 제거 + 인메모리 반복 최적화)

---

### 🐞 Issue 1: `ExpenseInquiryService.getMonthlyTotalList()`

* **문제**: `1 + N` 쿼리 (월 목록 조회 + 월별 합계 반복 조회)
* **해결**: `GROUP BY` 단일 쿼리로 변경 → **1회 쿼리**

---

### 🐞 Issue 2: `WeeklyRecordService.getMonthlyReportArrivals()`

* **문제**: N+1 패턴 + 미사용 쿼리 (Dead Code)
* **해결**: 집계 쿼리 재사용 + 불필요 호출 제거 → **2회 쿼리**

---

### 🐞 Issue 3: Monthly/WeeklyDetailRecordService

* **문제**: 동일 리스트 반복 순회 (filter + count + sum 구조)
* **해결**: `groupingBy`로 1회 순회 후 Map 재사용

---

### 📊 요약

* **쿼리 최적화**: N+1 → 단일/최소 쿼리
* **메모리 연산 최적화**: 반복 순회 → 단일 순회

---
