### PR TITLE
⚡ Perf:  Hibernate 7.2 JPQL 검증 실패로 인한 서버 기동 오류 수정

### DIFF
--- a/src/main/java/com/nitrogen/domain/expense/dto/calendar/MonthlyAmountDTO.java
+++ b/src/main/java/com/nitrogen/domain/expense/dto/calendar/MonthlyAmountDTO.java
@@ -1,6 +1,6 @@
 package com.nitrogen.domain.expense.dto.calendar;
 
-public record MonthlyAmountDTO(
-        String month,
-        Long totalAmount
-) {}
+public interface MonthlyAmountDTO {
+    String getMonth();
+    Long getTotalAmount();
+}

--- a/src/main/java/com/nitrogen/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/com/nitrogen/domain/expense/repository/ExpenseRepository.java
@@ -81,11 +81,9 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
     List<String> findDistinctMonthsByUserId(@Param("userId") Long userId);
 
     // 사용자의 월별 지출 합계 조회 (월 목록 + 합계를 한 번에)
-    @Query("SELECT new com.nitrogen.domain.expense.dto.calendar.MonthlyAmountDTO(" +
-            "FUNCTION('DATE_FORMAT', e.expendedAt, '%Y-%m-01'), SUM(e.amount)) " +
-            "FROM Expense e WHERE e.user.userId = :userId " +
-            "GROUP BY FUNCTION('DATE_FORMAT', e.expendedAt, '%Y-%m-01') " +
-            "ORDER BY FUNCTION('DATE_FORMAT', e.expendedAt, '%Y-%m-01') DESC")
+    @Query(value = "SELECT DATE_FORMAT(e.expended_at, '%Y-%m-01') AS month, SUM(e.amount) AS totalAmount " +
+            "FROM expense e WHERE e.user_id = :userId " +
+            "GROUP BY month ORDER BY month DESC", nativeQuery = true)
     List<MonthlyAmountDTO> findMonthlyTotalsByUserId(@Param("userId") Long userId);
 
     // 유저의 지출 중 오늘 이전 날짜이면서 아직 평가가 되지 않은 것이 있는지 확인

--- a/src/main/java/com/nitrogen/domain/expense/service/inquiry/ExpenseInquiryService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/inquiry/ExpenseInquiryService.java
@@ -124,14 +124,14 @@ public class ExpenseInquiryService {
 
         return monthlyTotals.stream()
                 .map(dto -> {
-                    LocalDate startOfMonth = LocalDate.parse(dto.month());
+                    LocalDate startOfMonth = LocalDate.parse(dto.getMonth());
                     LocalDate reportOpenDate = startOfMonth.plusMonths(1);
                     boolean isOpened = !now.isBefore(reportOpenDate); // now.isAfter(reportOpenDate) || now.isEqual(reportOpenDate);
 
                     return new MonthlyReportSummaryResponse(
                             String.valueOf(startOfMonth.getYear() % 100), // 2026 -> 26 변환
                             String.valueOf(startOfMonth.getMonthValue()),
-                            dto.totalAmount(),
+                            dto.getTotalAmount(),
                             isOpened
                     );
                 })

--- a/src/main/java/com/nitrogen/domain/expense/service/report/WeeklyRecordService.java
+++ b/src/main/java/com/nitrogen/domain/expense/service/report/WeeklyRecordService.java
@@ -45,7 +45,7 @@ public class WeeklyRecordService {
 
         return monthsWithExpenses.stream()
                 .map(dto -> {
-                    LocalDate startOfMonth = LocalDate.parse(dto.month());
+                    LocalDate startOfMonth = LocalDate.parse(dto.getMonth());
                     LocalDate reportOpenDate = startOfMonth.plusMonths(1);
 
                     // 다음달 1일이 지나야 리포트가 "도착"한 상태

--- a/src/test/java/com/nitrogen/domain/expense/service/inquiry/ExpenseInquiryServiceTest.java
+++ b/src/test/java/com/nitrogen/domain/expense/service/inquiry/ExpenseInquiryServiceTest.java
@@ -26,6 +26,13 @@ class ExpenseInquiryServiceTest {
     @InjectMocks
     ExpenseInquiryService expenseInquiryService;
 
+    private MonthlyAmountDTO createMonthlyAmountDTO(String month, Long totalAmount) {
+        MonthlyAmountDTO dto = mock(MonthlyAmountDTO.class);
+        when(dto.getMonth()).thenReturn(month);
+        when(dto.getTotalAmount()).thenReturn(totalAmount);
+        return dto;
+    }
+
     @Test
     @DisplayName("N+1 유발 메서드를 사용하지 않고 단일 쿼리 방식으로 조회한다")
     void getMonthlyTotalList_단일_쿼리로_조회() {
@@ -33,9 +40,9 @@ class ExpenseInquiryServiceTest {
         Long userId = 1L;
         int monthCount = 3;
         List<MonthlyAmountDTO> mockData = List.of(
-                new MonthlyAmountDTO("2026-03-01", 150000L),
-                new MonthlyAmountDTO("2026-02-01", 200000L),
-                new MonthlyAmountDTO("2026-01-01", 100000L)
+                createMonthlyAmountDTO("2026-03-01", 150000L),
+                createMonthlyAmountDTO("2026-02-01", 200000L),
+                createMonthlyAmountDTO("2026-01-01", 100000L)
         );
         when(expenseRepository.findMonthlyTotalsByUserId(userId)).thenReturn(mockData);
 
@@ -62,8 +69,8 @@ class ExpenseInquiryServiceTest {
         // given
         Long userId = 1L;
         List<MonthlyAmountDTO> mockData = List.of(
-                new MonthlyAmountDTO("2026-03-01", 150000L),
-                new MonthlyAmountDTO("2026-01-01", 100000L)
+                createMonthlyAmountDTO("2026-03-01", 150000L),
+                createMonthlyAmountDTO("2026-01-01", 100000L)
         );
 
         when(expenseRepository.findMonthlyTotalsByUserId(userId)).thenReturn(mockData);


### PR DESCRIPTION
## 원인

SELECT new MonthlyAmountDTO(
  FUNCTION('DATE_FORMAT', ...),
  SUM(e.amount)
)

FUNCTION('DATE_FORMAT', ...)의 반환 타입을 Hibernate가 인식하지 못하는 문제
SUM(e.amount) → Long ✔
FUNCTION('DATE_FORMAT', ...) → ❓

 -> MonthlyAmountDTO(String, Long) 생성자를
찾지 못하고 셧다운 

## 해결

native query로 변경(Hibernate JPQL 파싱 패스)